### PR TITLE
forced cmake to consider the 2.* versions of python first

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@
 #
 # Python
 #
+set(Python_ADDITIONAL_VERSIONS 2.7 2.6 2.5 2.4 2.3 2.2 2.1 2.0)
 INCLUDE(../cmake/python.cmake)
 FINDPYTHON()
 


### PR DESCRIPTION
Specifying the additional_versions variable will force the python version to 2._, if one of the 2._ versions is installed.
