### PR TITLE
Add a method to test the existence of a signal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ SET(PKG_CONFIG_ADDITIONAL_VARIABLES plugindir ${PKG_CONFIG_ADDITIONAL_VARIABLES}
 SETUP_PROJECT()
 
 # Trigger dependency to dynamic-graph.
-ADD_REQUIRED_DEPENDENCY("dynamic-graph >= 1.0")
+ADD_REQUIRED_DEPENDENCY("dynamic-graph >= 2.5.5-6")
 
 # Add dependency toward dynamic graph library in pkg-config file.
 PKG_CONFIG_APPEND_LIBS("dynamic-graph-python")

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -48,6 +48,7 @@ namespace dynamicgraph {
       extern PyObject* display(PyObject* self, PyObject* args);
       extern PyObject* display(PyObject* self, PyObject* args);
       extern PyObject* getName(PyObject* self, PyObject* args);
+      extern PyObject* hasSignal(PyObject* self, PyObject* args);
       extern PyObject* getSignal(PyObject* self, PyObject* args);
       extern PyObject* listSignals(PyObject* self, PyObject* args);
       extern PyObject* executeCommand(PyObject* self, PyObject* args);
@@ -179,6 +180,8 @@ static PyMethodDef dynamicGraphMethods[] = {
    "print an Entity C++ object"},
   {"entity_get_name", dynamicgraph::python::entity::getName, METH_VARARGS,
    "get the name of an Entity"},
+  {"entity_has_signal", dynamicgraph::python::entity::hasSignal, METH_VARARGS,
+   "return True if the entity has a signal with the given name"},
   {"entity_get_signal", dynamicgraph::python::entity::getSignal, METH_VARARGS,
    "get signal by name from an Entity"},
   {"entity_list_signals", dynamicgraph::python::entity::listSignals,

--- a/src/dynamic_graph/entity.py
+++ b/src/dynamic_graph/entity.py
@@ -107,6 +107,12 @@ class Entity (object) :
         signalPt = wrap.entity_get_signal(self.obj, name)
         return signal_base.SignalBase(name = "", obj = signalPt)
 
+    def hasSignal(self, name) :
+        """
+        Indicates if a signal with the given name exists in the entity
+        """
+        return wrap.entity_has_signal(self.obj, name)
+
     def displaySignals(self) :
         """
         Print the list of signals into standard output: temporary.

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -113,7 +113,40 @@ namespace dynamicgraph {
       }
 
       /**
-	 \brief Get a signal by name
+         \brief Check if the entity has a signal with the given name
+      */
+      PyObject * hasSignal(PyObject* /*self*/, PyObject* args)
+      {
+        char *name = NULL;
+        PyObject* object = NULL;
+        void* pointer = NULL;
+
+	if (!PyArg_ParseTuple(args, "Os", &object, &name))
+	  Py_RETURN_FALSE;
+
+	if (!PyCObject_Check(object)) {
+	  PyErr_SetString(PyExc_TypeError,
+			  "function takes a PyCObject as argument");
+	  Py_RETURN_FALSE;
+	}
+
+	pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	bool hasSignal = false;
+	try {
+	  hasSignal = entity->hasSignal(std::string(name));
+	} CATCH_ALL_EXCEPTIONS();
+
+	if (hasSignal)
+	  Py_RETURN_TRUE;
+	else
+	  Py_RETURN_FALSE;
+      }
+
+
+      /**
+         \brief Get a signal by name
       */
       PyObject* getSignal(PyObject* /*self*/, PyObject* args)
       {


### PR DESCRIPTION
The goal of this commit is to add a way to know if a signal exists in an entity without retrieving this signal.
Especially in the python interface, I didn't find a way to have this information unless by getting the signal, and catching the exception if the signal does not exist.

This can be useful for the entities that can create signals on the fly.
