### PR TITLE
Remove test for deprecated function

### DIFF
--- a/unitTesting/interpreter-test.cc
+++ b/unitTesting/interpreter-test.cc
@@ -10,20 +10,12 @@ int main(int argc, char ** argv)
 
   dynamicgraph::python::Interpreter interp;
   std::string command;
+  std::string result;
+  std::string out;
+  std::string err;
 
   for (int i=0; i<numTest; ++i)
   {
-    //correct input
-    command = "print \"Hello world\"";
-    interp.python(command);
-
-    //incorrect input
-    command = "print Hello";
-    interp.python(command);
-
-    std::string result;
-    std::string out;
-    std::string err;
     //correct input
     interp.python("print \"I am the interpreter\"", result, out, err);
     //incorrect input


### PR DESCRIPTION
Hi,

This pull-request removes test calls to the deprecated functions in the python interpreter.

This should fix travis build.
