### PR TITLE
Prevent running several instances of the python command simultaneously, Close #11.

### DIFF
--- a/include/dynamic-graph/python/interpreter.hh
+++ b/include/dynamic-graph/python/interpreter.hh
@@ -20,6 +20,7 @@
 #include <string>
 #include "dynamic-graph/python/api.hh"
 #include "dynamic-graph/python/deprecated.hh"
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
 
 #ifndef DYNAMIC_GRAPH_PYTHON_INTERPRETER_H
 # define DYNAMIC_GRAPH_PYTHON_INTERPRETER_H
@@ -68,6 +69,8 @@ namespace dynamicgraph {
       PyObject* locals_;
       PyObject* mainmod_;
       PyObject* traceback_format_exception_;
+
+      boost::shared_ptr<boost::interprocess::interprocess_mutex> mutex_;
     };
   } // namespace python
 } // namespace dynamicgraph


### PR DESCRIPTION
Otherwise, this may lead to a crash when using the rosservice run_command.
