### PR TITLE
Disable -Werror on Unix for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
+IF(UNIX)
+  # Disable -Werror on Unix for now.
+  SET(CXX_DISABLE_WERROR True)
+ENDIF(UNIX)
+
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/boost.cmake)
 INCLUDE(cmake/pthread.cmake)


### PR DESCRIPTION
Otherwise it generates the following error :
error: conversion to ‘unsigned int’ from ‘Py_ssize_t {aka long int}’ may alter its value [-Werror=conversion]

Should be fixed in the future
