### PR TITLE
Add SignalWrapper to plug python function into signal

### DIFF
--- a/include/dynamic-graph/python/interpreter.hh
+++ b/include/dynamic-graph/python/interpreter.hh
@@ -62,6 +62,8 @@ namespace dynamicgraph {
       PyObject* globals();
 
     private:
+      /// The Pythone thread state
+      PyThreadState *_pyState;
       /// Pointer to the dictionary of global variables
       PyObject* globals_;
       /// Pointer to the dictionary of local variables

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ ADD_LIBRARY(${PYTHON_MODULE}
 	factory-py.cc
 	pool-py.cc
 	signal-caster-py.cc
+	signal-wrapper.cc
 )
 
 # Remove prefix lib

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -23,6 +23,7 @@
 #include <dynamic-graph/signal-base.h>
 
 #include "exception.hh"
+#include "signal-wrapper.hh"
 
 namespace dynamicgraph {
   namespace python {
@@ -30,6 +31,7 @@ namespace dynamicgraph {
     // Declare functions defined in other source files
     namespace signalBase {
       extern PyObject* create(PyObject* self, PyObject* args);
+      extern PyObject* createSignalWrapper(PyObject* self, PyObject* args);
       extern PyObject* getTime(PyObject* self, PyObject* args);
       extern PyObject* setTime(PyObject* self, PyObject* args);
       extern PyObject* getName(PyObject* self, PyObject* args);
@@ -151,6 +153,8 @@ static PyMethodDef dynamicGraphMethods[] = {
   // Signals
   {"create_signal_base", dynamicgraph::python::signalBase::create, METH_VARARGS,
    "create a SignalBase C++ object"},
+  {"create_signal_wrapper", dynamicgraph::python::signalBase::createSignalWrapper, METH_VARARGS,
+   "create a SignalWrapper C++ object"},
   {"signal_base_get_time", dynamicgraph::python::signalBase::getTime,
    METH_VARARGS, "Get time of  a SignalBase"},
   {"signal_base_set_time", dynamicgraph::python::signalBase::setTime,

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -48,6 +48,7 @@ namespace dynamicgraph {
       extern PyObject* display(PyObject* self, PyObject* args);
       extern PyObject* display(PyObject* self, PyObject* args);
       extern PyObject* getName(PyObject* self, PyObject* args);
+      extern PyObject* getClassName(PyObject* self, PyObject* args);
       extern PyObject* hasSignal(PyObject* self, PyObject* args);
       extern PyObject* getSignal(PyObject* self, PyObject* args);
       extern PyObject* listSignals(PyObject* self, PyObject* args);
@@ -181,6 +182,8 @@ static PyMethodDef dynamicGraphMethods[] = {
    "print an Entity C++ object"},
   {"entity_get_name", dynamicgraph::python::entity::getName, METH_VARARGS,
    "get the name of an Entity"},
+  {"entity_get_class_name", dynamicgraph::python::entity::getClassName, METH_VARARGS,
+   "get the class name of an Entity"},
   {"entity_has_signal", dynamicgraph::python::entity::hasSignal, METH_VARARGS,
    "return True if the entity has a signal with the given name"},
   {"entity_get_signal", dynamicgraph::python::entity::getSignal, METH_VARARGS,

--- a/src/dynamic_graph/entity.py
+++ b/src/dynamic_graph/entity.py
@@ -97,6 +97,10 @@ class Entity (object) :
     def name(self) :
         return wrap.entity_get_name(self.obj)
 
+    @property
+    def className(self) :
+        return wrap.entity_get_class_name(self.obj)
+
     def __str__(self) :
         return wrap.display_entity(self.obj)
 

--- a/src/dynamic_graph/signal_base.py
+++ b/src/dynamic_graph/signal_base.py
@@ -270,4 +270,7 @@ class SignalBase (object) :
         """
         return(wrap.signal_base_display_dependencies(self.obj,iter))
 
-
+class SignalWrapper (SignalBase):
+    def __init__ (self, name, type, func):
+        super(SignalWrapper, self).__init__ (name,
+                wrap.create_signal_wrapper (name, type, func))

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -114,6 +114,32 @@ namespace dynamicgraph {
       }
 
       /**
+	 \brief Get class name of entity
+      */
+      PyObject* getClassName(PyObject* /*self*/, PyObject* args)
+      {
+	PyObject* object = NULL;
+	void* pointer = NULL;
+	std::string name;
+
+	if (!PyArg_ParseTuple(args, "O", &object))
+	  return NULL;
+	if (!PyCObject_Check(object)) {
+	  PyErr_SetString(PyExc_TypeError,
+			  "function takes a PyCObject as argument");
+	  return NULL;
+	}
+
+	pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	try {
+	 name = entity->getClassName();
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue("s", name.c_str());
+      }
+
+      /**
          \brief Check if the entity has a signal with the given name
       */
       PyObject * hasSignal(PyObject* /*self*/, PyObject* args)

--- a/src/signal-base-py.cc
+++ b/src/signal-base-py.cc
@@ -22,6 +22,8 @@
 #include <dynamic-graph/signal-ptr.h>
 #include <dynamic-graph/signal-caster.h>
 #include <dynamic-graph/linear-algebra.h>
+#include <dynamic-graph/pool.h>
+#include <dynamic-graph/factory.h>
 
 #include "convert-dg-to-py.hh"
 #include "exception.hh"
@@ -57,7 +59,7 @@ namespace dynamicgraph {
 	return PyCObject_FromVoidPtr((void*)obj, destroy);
       }
 
-      template <class T> void* createSignalWrapperTpl (const char* name, PyObject* o, std::string& error)
+      template <class T> SignalWrapper<T, int>* createSignalWrapperTpl (const char* name, PyObject* o, std::string& error)
       {
         typedef SignalWrapper<T, int> SignalWrapper_t;
         if (!SignalWrapper_t::checkCallable (o, error)) {
@@ -65,7 +67,33 @@ namespace dynamicgraph {
         }
 
         SignalWrapper_t* obj = new SignalWrapper_t(name, o);
-        return (void*) obj;
+        return obj;
+      }
+
+      PythonSignalContainer* getPythonSignalContainer ()
+      {
+        const std::string instanceName = "python_signals";
+        const std::string className = "PythonSignalContainer";
+        Entity* obj;
+        if( PoolStorage::getInstance()->existEntity(instanceName, obj))
+        {
+          if( obj->getClassName()!=className ) {
+            std::string msg ("Found an object named "
+                + std::string(instanceName)
+                + ",\n""but this object is of type "
+                + std::string(obj->getClassName())
+                + " and not "
+                + std::string(className));
+            PyErr_SetString(dgpyError, msg.c_str());
+            return NULL;
+          }
+        } else {
+          try {
+            obj = FactoryStorage::getInstance()->newEntity
+              (std::string(className), std::string(instanceName));
+          } CATCH_ALL_EXCEPTIONS();
+        }
+        return dynamic_cast<PythonSignalContainer*>(obj);
       }
 
 #define SIGNAL_WRAPPER_TYPE(IF, Enum, Type)                             \
@@ -79,6 +107,10 @@ namespace dynamicgraph {
       */
       PyObject* createSignalWrapper(PyObject* /*self*/, PyObject* args)
       {
+        PythonSignalContainer* psc = getPythonSignalContainer();
+        if (psc == NULL)
+          return NULL;
+
 	char *name = NULL;
 	char *type = NULL;
 	PyObject* object = NULL;
@@ -86,7 +118,7 @@ namespace dynamicgraph {
 	if (!PyArg_ParseTuple(args, "ssO", &name, &type, &object))
 	  return NULL;
 
-        void* obj = NULL;
+        SignalBase<int>* obj = NULL;
         std::string error;
         SIGNAL_WRAPPER_TYPE(     if, BOOL     ,bool)
         // SIGNAL_WRAPPER_TYPE(else if, UNSIGNED ,bool)
@@ -105,8 +137,11 @@ namespace dynamicgraph {
           PyErr_SetString(dgpyError, error.c_str());
           return NULL;
         }
+        // Register signal into the python signal container
+        psc->signalRegistration(*obj);
+
 	// Return the pointer
-	return PyCObject_FromVoidPtr(obj, destroy);
+	return PyCObject_FromVoidPtr((void*)obj, destroy);
       }
 
       /**

--- a/src/signal-wrapper.cc
+++ b/src/signal-wrapper.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2018, Joseph Mirabel
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of dynamic-graph-python.
+// dynamic-graph-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// dynamic-graph-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// dynamic-graph-python. If not, see <http://www.gnu.org/licenses/>.
+
+#include <Python.h>
+
+#include <signal-wrapper.hh>
+
+namespace dynamicgraph {
+  namespace python {
+    namespace signalWrapper {
+      void convert (PyObject* o, bool  & v) { v = (o == Py_True); }
+      void convert (PyObject* o, int   & v) { v = (int)PyInt_AS_LONG (o); }
+      void convert (PyObject* o, float & v) { v = (float)PyFloat_AS_DOUBLE (o); }
+      void convert (PyObject* o, double& v) { v =        PyFloat_AS_DOUBLE (o); }
+      void convert (PyObject* o, Vector     & v)
+      {
+        v.resize(PyTuple_Size(o));
+        for (int i = 0; i < v.size(); ++i)
+          convert(PyTuple_GetItem(o,i), v[i]);
+      }
+    }
+
+    template <class T, class Time>
+    bool SignalWrapper<T,Time>::checkCallable (PyObject* c, std::string& error)
+    {
+      if (PyCallable_Check(c) == 0) {
+        PyObject* str = PyObject_Str(c);
+        error = PyString_AsString(str);
+        error += " is not callable";
+        Py_DECREF(str);
+        return false;
+      }
+      return true;
+    }
+
+    template class SignalWrapper<bool  , int>;
+    template class SignalWrapper<int   , int>;
+    template class SignalWrapper<float , int>;
+    template class SignalWrapper<double, int>;
+    template class SignalWrapper<Vector, int>;
+  } // namespace dynamicgraph
+} // namespace python

--- a/src/signal-wrapper.cc
+++ b/src/signal-wrapper.cc
@@ -14,9 +14,10 @@
 // received a copy of the GNU Lesser General Public License along with
 // dynamic-graph-python. If not, see <http://www.gnu.org/licenses/>.
 
-#include <Python.h>
-
 #include <signal-wrapper.hh>
+
+#include <Python.h>
+#include <dynamic-graph/factory.h>
 
 namespace dynamicgraph {
   namespace python {
@@ -32,6 +33,8 @@ namespace dynamicgraph {
           convert(PyTuple_GetItem(o,i), v[i]);
       }
     }
+
+    DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN(PythonSignalContainer, "PythonSignalContainer");
 
     template <class T, class Time>
     bool SignalWrapper<T,Time>::checkCallable (PyObject* c, std::string& error)

--- a/src/signal-wrapper.cc
+++ b/src/signal-wrapper.cc
@@ -34,6 +34,16 @@ namespace dynamicgraph {
       }
     }
 
+    PythonSignalContainer::PythonSignalContainer(const std::string& name)
+      : Entity (name)
+    {
+    }
+
+    void PythonSignalContainer::signalRegistration (const SignalArray<int>& signals)
+    {
+      Entity::signalRegistration (signals);
+    }
+
     DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN(PythonSignalContainer, "PythonSignalContainer");
 
     template <class T, class Time>

--- a/src/signal-wrapper.cc
+++ b/src/signal-wrapper.cc
@@ -18,6 +18,7 @@
 
 #include <Python.h>
 #include <dynamic-graph/factory.h>
+#include <dynamic-graph/command-bind.h>
 
 namespace dynamicgraph {
   namespace python {
@@ -37,11 +38,26 @@ namespace dynamicgraph {
     PythonSignalContainer::PythonSignalContainer(const std::string& name)
       : Entity (name)
     {
+      std::string docstring;
+
+      docstring = "    \n"
+        "    Remove a signal\n"
+        "    \n"
+        "      Input:\n"
+        "        - name of the signal\n"
+        "    \n";
+      addCommand("rmSignal",
+	     command::makeCommandVoid1(*this,&PythonSignalContainer::rmSignal,docstring));
     }
 
     void PythonSignalContainer::signalRegistration (const SignalArray<int>& signals)
     {
       Entity::signalRegistration (signals);
+    }
+
+    void PythonSignalContainer::rmSignal (const std::string& name)
+    {
+      Entity::signalDeregistration (name);
     }
 
     DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN(PythonSignalContainer, "PythonSignalContainer");

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -72,6 +72,11 @@ namespace dynamicgraph {
       private:
         T& call (T& value, Time t)
         {
+          PyGILState_STATE gstate;
+          gstate = PyGILState_Ensure();
+          if (PyGILState_GetThisThreadState() == NULL) {
+            dgDEBUG(10) << "python thread not initialized" << std::endl;
+          }
           char format[] = "i";
           PyObject* obj = PyObject_CallFunction(callable, format, t);
           if (obj == NULL)
@@ -80,6 +85,7 @@ namespace dynamicgraph {
             signalWrapper::convert (obj, value);
             Py_DECREF(obj);
           }
+          PyGILState_Release (gstate);
           return value;
         }
         PyObject* callable;

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -18,6 +18,7 @@
 
 #include <dynamic-graph/linear-algebra.h>
 #include <dynamic-graph/signal.h>
+#include <dynamic-graph/entity.h>
 
 namespace dynamicgraph {
   namespace python {
@@ -31,6 +32,19 @@ namespace dynamicgraph {
       // void convert (PyObject* o, Eigen::MatrixXd& v);
       // void convert (PyObject* o, Eigen::Matrix4d& v);
     }
+
+    class PythonSignalContainer : public Entity
+    {
+      DYNAMIC_GRAPH_ENTITY_DECL();
+
+      public:
+        PythonSignalContainer (const std::string& name) : Entity (name) {};
+
+        void signalRegistration (const SignalArray<int>& signals)
+        {
+          Entity::signalRegistration (signals);
+        }
+    };
 
     template <class T, class Time>
     class SignalWrapper : public Signal<T, Time>

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -41,6 +41,8 @@ namespace dynamicgraph {
         PythonSignalContainer (const std::string& name);
 
         void signalRegistration (const SignalArray<int>& signals);
+
+        void rmSignal (const std::string& name);
     };
 
     template <class T, class Time>

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -57,23 +57,16 @@ namespace dynamicgraph {
         SignalWrapper (std::string name, PyObject* _callable) : 
           parent_t (name)
           , callable (_callable)
-          // , argsTuple (NULL)
-          // , argTime (NULL)
-          // , argValue (NULL)
         {
           typedef boost::function2<T&,T&,Time> function_t;
           Py_INCREF(callable);
           function_t f = boost::bind (&SignalWrapper::call, this, _1, _2);
           this->setFunction (f);
-
-          // argsTuple = PyTuple_New(1);
-          // argTime = Py
         }
 
         virtual ~SignalWrapper ()
         {
           Py_DECREF(callable);
-          // Py_DECREF(args);
         };
 
       private:
@@ -90,9 +83,6 @@ namespace dynamicgraph {
           return value;
         }
         PyObject* callable;
-        // PyObject* argsTuple;
-        // PyObject* argTime;
-        // PyObject* argValue;
     };
 
   } // namespace dynamicgraph

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -38,12 +38,9 @@ namespace dynamicgraph {
       DYNAMIC_GRAPH_ENTITY_DECL();
 
       public:
-        PythonSignalContainer (const std::string& name) : Entity (name) {};
+        PythonSignalContainer (const std::string& name);
 
-        void signalRegistration (const SignalArray<int>& signals)
-        {
-          Entity::signalRegistration (signals);
-        }
+        void signalRegistration (const SignalArray<int>& signals);
     };
 
     template <class T, class Time>

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -1,0 +1,85 @@
+// Copyright (c) 2018, Joseph Mirabel
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of dynamic-graph-python.
+// dynamic-graph-python is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// dynamic-graph-python is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// dynamic-graph-python. If not, see <http://www.gnu.org/licenses/>.
+
+#include <Python.h>
+
+#include <dynamic-graph/linear-algebra.h>
+#include <dynamic-graph/signal.h>
+
+namespace dynamicgraph {
+  namespace python {
+    namespace signalWrapper {
+      void convert (PyObject* o, int   & v);
+      void convert (PyObject* o, bool  & v);
+      void convert (PyObject* o, float & v);
+      void convert (PyObject* o, double& v);
+      // void convert (PyObject* o, std::string& v);
+      void convert (PyObject* o, Vector     & v);
+      // void convert (PyObject* o, Eigen::MatrixXd& v);
+      // void convert (PyObject* o, Eigen::Matrix4d& v);
+    }
+
+    template <class T, class Time>
+    class SignalWrapper : public Signal<T, Time>
+    {
+      public:
+        typedef Signal<T,Time> parent_t;
+
+        static bool checkCallable (PyObject* c, std::string& error);
+
+        SignalWrapper (std::string name, PyObject* _callable) : 
+          parent_t (name)
+          , callable (_callable)
+          // , argsTuple (NULL)
+          // , argTime (NULL)
+          // , argValue (NULL)
+        {
+          typedef boost::function2<T&,T&,Time> function_t;
+          Py_INCREF(callable);
+          function_t f = boost::bind (&SignalWrapper::call, this, _1, _2);
+          this->setFunction (f);
+
+          // argsTuple = PyTuple_New(1);
+          // argTime = Py
+        }
+
+        virtual ~SignalWrapper ()
+        {
+          Py_DECREF(callable);
+          // Py_DECREF(args);
+        };
+
+      private:
+        T& call (T& value, Time t)
+        {
+          char format[] = "i";
+          PyObject* obj = PyObject_CallFunction(callable, format, t);
+          if (obj == NULL)
+            std::cerr << "Could not call callable" << std::endl;
+          else {
+            signalWrapper::convert (obj, value);
+            Py_DECREF(obj);
+          }
+          return value;
+        }
+        PyObject* callable;
+        // PyObject* argsTuple;
+        // PyObject* argTime;
+        // PyObject* argValue;
+    };
+
+  } // namespace dynamicgraph
+} // namespace python

--- a/src/signal-wrapper.hh
+++ b/src/signal-wrapper.hh
@@ -78,9 +78,9 @@ namespace dynamicgraph {
           }
           char format[] = "i";
           PyObject* obj = PyObject_CallFunction(callable, format, t);
-          if (obj == NULL)
-            std::cerr << "Could not call callable" << std::endl;
-          else {
+          if (obj == NULL) {
+            dgERROR << "Could not call callable" << std::endl;
+          } else {
             signalWrapper::convert (obj, value);
             Py_DECREF(obj);
           }


### PR DESCRIPTION
This PR makes it possible to cast a python function as a signal, for debugging purpose (mainly, pass the signal to `robot.device.after.addSignal` so that your function is called at any timestep).

The main drawback of this PR are:
- it should be used for debugging purpose as the python function will likely be slower than its C++ equivalent (though this is questionable for simple functions),
- it adds some complexity in the C++ code due to Python thread management (commit
53f8fa1).

#### Storage of the signals
The signal of type `SignalWrapper` are stored in a singleton entity `python_signals` of type `PythonSignalsContainer`. Although I am not very satisfied with this method, it is the cleanest way of giving access to the signals. All the python API refers to signals via its parent entity.

#### Minor changes
The addition of `Entity.className` and `entity_get_class_name` to python interpreter are in PR https://github.com/stack-of-tasks/dynamic-graph-python/pull/16 .