### PR TITLE
Expose set/getTimeSample and set/getStreamPrintPeriod

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,16 +54,17 @@ INSTALL(TARGETS ${LIBRARY_NAME}
 SET(PYTHON_MODULE wrap)
 
 ADD_LIBRARY(${PYTHON_MODULE}
-	MODULE
-	exception-python.cc
-	convert-dg-to-py.cc
-	dynamic-graph-py.cc
-	signal-base-py.cc
-	entity-py.cc
-	factory-py.cc
-	pool-py.cc
-	signal-caster-py.cc
-	signal-wrapper.cc
+  MODULE
+  convert-dg-to-py.cc
+  debug-py.cc
+  dynamic-graph-py.cc
+  entity-py.cc
+  exception-python.cc
+  factory-py.cc
+  pool-py.cc
+  signal-base-py.cc
+  signal-caster-py.cc
+  signal-wrapper.cc
 )
 
 # Remove prefix lib
@@ -117,5 +118,3 @@ ELSE(WIN32)
 SET(TRACERREALTIME_PLUGIN ${DYNAMIC_GRAPH_PLUGINDIR}/tracer-real-time${CMAKE_SHARED_LIBRARY_SUFFIX})
 ENDIF(WIN32)
 DYNAMIC_GRAPH_PYTHON_MODULE("tracer_real_time" ${TRACERREALTIME_PLUGIN} tracer_real_time-wrap)
-
-

--- a/src/debug-py.cc
+++ b/src/debug-py.cc
@@ -1,0 +1,95 @@
+// Copyright 2019, Olivier Stasse, LAAS-CNRS.
+//
+// See LICENSE
+
+#include <iostream>
+
+#define ENABLE_RT_LOG
+#include <dynamic-graph/real-time-logger.h>
+
+#include <map>
+#include <Python.h>
+#include <dynamic-graph/pool.h>
+#include <dynamic-graph/entity.h>
+#include <vector>
+#include "exception.hh"
+
+#include <boost/shared_ptr.hpp>
+
+typedef boost::shared_ptr<std::ofstream> ofstreamShrPtr;
+
+namespace dynamicgraph {
+  namespace python {
+
+    extern PyObject* dgpyError;
+    namespace debug {
+
+      std::map<std::string, ofstreamShrPtr > mapOfFiles_;
+
+      PyObject* addLoggerFileOutputStream (PyObject* /*self*/, PyObject* args)
+      {
+	char* filename;
+	if (!PyArg_ParseTuple(args, "s", &filename))
+	  return NULL;
+	std::string sfilename(filename);
+	try {
+	  std::ofstream *aofs = new std::ofstream;
+	  ofstreamShrPtr ofs_shrptr = boost::shared_ptr<std::ofstream>(aofs);
+	  aofs->open(filename,
+		     std::ofstream::out);
+	  dynamicgraph::RealTimeLogger::instance();
+	  dgADD_OSTREAM_TO_RTLOG(*aofs);
+	  dgRTLOG() << "Added " << filename << " as an output stream \n";
+	  mapOfFiles_[sfilename]= ofs_shrptr;
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+      PyObject* closeLoggerFileOutputStream (PyObject* /*self*/, PyObject* /*args */)
+      {
+	try {
+	  for (std::map<std::string,ofstreamShrPtr>::iterator
+		  it=mapOfFiles_.begin();
+		it!=mapOfFiles_.end(); ++it)
+	     {
+	       it->second->close();
+	     }
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+      PyObject* addLoggerCoutOutputStream (PyObject* /*self*/, PyObject* /*args*/)
+      {
+	try {
+	  dgADD_OSTREAM_TO_RTLOG(std::cout);
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+      PyObject* realTimeLoggerDestroy (PyObject* /*self*/, PyObject* /*args*/)
+      {
+	try {
+	  RealTimeLogger::destroy();
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+      PyObject* realTimeLoggerSpinOnce (PyObject* /*self*/, PyObject* /*args*/)
+      {
+	try {
+	  RealTimeLogger::instance().spinOnce();
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+      PyObject* realTimeLoggerInstance (PyObject* /*self*/, PyObject* /*args*/)
+      {
+	try {
+	  RealTimeLogger::instance();
+	} CATCH_ALL_EXCEPTIONS();
+	return Py_BuildValue ("");
+      }
+
+    } // python
+  } // namespace debug
+} // dynamicgraph

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -170,7 +170,7 @@ static PyMethodDef dynamicGraphMethods[] = {
   {"signal_base_display_dependencies", dynamicgraph::python::signalBase::displayDependencies,
    METH_VARARGS, "Print the signal dependencies in a string"},
   {"signal_base_get_value", dynamicgraph::python::signalBase::getValue,
-   METH_VARARGS, "Read the value of a signal"}, 
+   METH_VARARGS, "Read the value of a signal"},
   {"signal_base_set_value", dynamicgraph::python::signalBase::setValue,
    METH_VARARGS, "Set the value of a signal"},
   {"signal_base_recompute", dynamicgraph::python::signalBase::recompute,
@@ -236,7 +236,7 @@ static PyMethodDef dynamicGraphMethods[] = {
   {"entity_get_logger_verbosity",
    dynamicgraph::python::entity::getLoggerVerbosityLevel,
    METH_VARARGS,
-   "get the verbosity level of the entity"},  
+   "get the verbosity level of the entity"},
   {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -58,6 +58,8 @@ namespace dynamicgraph {
       extern PyObject* listCommands(PyObject* self, PyObject* args);
       extern PyObject* getCommandDocstring(PyObject* self, PyObject* args);
       extern PyObject* getDocString(PyObject* self, PyObject* args);
+      extern PyObject* setLoggerVerbosityLevel(PyObject*self, PyObject *args);
+      extern PyObject* getLoggerVerbosityLevel(PyObject *self, PyObject *args);
     }
 
     namespace factory {
@@ -227,6 +229,14 @@ static PyMethodDef dynamicGraphMethods[] = {
    dynamicgraph::python::pool::getEntityList,
    METH_VARARGS,
    "return the list of instanciated entities"},
+  {"entity_set_logger_verbosity",
+   dynamicgraph::python::entity::setLoggerVerbosityLevel,
+   METH_VARARGS,
+   "set the verbosity level of the entity"},
+  {"entity_get_logger_verbosity",
+   dynamicgraph::python::entity::getLoggerVerbosityLevel,
+   METH_VARARGS,
+   "get the verbosity level of the entity"},  
   {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/src/dynamic-graph-py.cc
+++ b/src/dynamic-graph-py.cc
@@ -60,6 +60,10 @@ namespace dynamicgraph {
       extern PyObject* getDocString(PyObject* self, PyObject* args);
       extern PyObject* setLoggerVerbosityLevel(PyObject*self, PyObject *args);
       extern PyObject* getLoggerVerbosityLevel(PyObject *self, PyObject *args);
+      extern PyObject* setTimeSample(PyObject*self, PyObject *args);
+      extern PyObject* getTimeSample(PyObject *self, PyObject *args);
+      extern PyObject* setStreamPrintPeriod(PyObject*self, PyObject *args);
+      extern PyObject* getStreamPrintPeriod(PyObject *self, PyObject *args);
     }
 
     namespace factory {
@@ -71,6 +75,15 @@ namespace dynamicgraph {
     namespace pool {
       extern PyObject* writeGraph (PyObject* self, PyObject* args);
       extern PyObject* getEntityList(PyObject* self, PyObject* args);
+    }
+    namespace debug {
+      extern PyObject* addLoggerFileOutputStream(PyObject* self, PyObject* args);
+      extern PyObject* addLoggerCoutOutputStream(PyObject* self, PyObject* args);
+      extern PyObject* closeLoggerFileOutputStream(PyObject* self, PyObject* args);
+      extern PyObject* realTimeLoggerSpinOnce(PyObject* self, PyObject* args);
+      extern PyObject* realTimeLoggerDestroy(PyObject* self, PyObject* args);
+      extern PyObject* realTimeLoggerInstance(PyObject* self, PyObject* args);
+
     }
 
     PyObject* dgpyError;
@@ -237,6 +250,46 @@ static PyMethodDef dynamicGraphMethods[] = {
    dynamicgraph::python::entity::getLoggerVerbosityLevel,
    METH_VARARGS,
    "get the verbosity level of the entity"},
+  {"addLoggerFileOutputStream",
+   dynamicgraph::python::debug::addLoggerFileOutputStream,
+   METH_VARARGS,
+   "add a output file stream to the logger by filename"},
+  {"addLoggerCoutOutputStream",
+   dynamicgraph::python::debug::addLoggerCoutOutputStream,
+   METH_VARARGS,
+   "add std::cout as output stream to the logger"},
+  {"closeLoggerFileOutputStream",
+   dynamicgraph::python::debug::closeLoggerFileOutputStream,
+   METH_VARARGS,
+   "close all the loggers file output streams."},
+  {"entity_set_time_sample",
+   dynamicgraph::python::entity::setTimeSample,
+   METH_VARARGS,
+   "set the time sample for printing debugging information"},
+  {"entity_get_time_sample",
+   dynamicgraph::python::entity::getTimeSample,
+   METH_VARARGS,
+   "get the time sample for printing debugging information"},
+  {"entity_set_stream_print_period",
+   dynamicgraph::python::entity::setStreamPrintPeriod,
+   METH_VARARGS,
+   "set the period at which debugging information are printed"},
+  {"entity_get_stream_print_period",
+   dynamicgraph::python::entity::getStreamPrintPeriod,
+   METH_VARARGS,
+   "get the period at which debugging information are printed"},
+  {"real_time_logger_destroy",
+   dynamicgraph::python::debug::realTimeLoggerDestroy,
+   METH_VARARGS,
+   "Destroy the real time logger."},
+  {"real_time_logger_spin_once",
+   dynamicgraph::python::debug::realTimeLoggerSpinOnce,
+   METH_VARARGS,
+   "Destroy the real time logger."},
+  {"real_time_logger_instance",
+   dynamicgraph::python::debug::realTimeLoggerInstance,
+   METH_VARARGS,
+   "Starts the real time logger."},
   {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/src/dynamic_graph/entity.py
+++ b/src/dynamic_graph/entity.py
@@ -61,6 +61,17 @@ def updateEntityClasses(dictionary):
 # --- ENTITY -------------------------------------------------------------------
 # --- ENTITY -------------------------------------------------------------------
 
+from enum import Enum
+class VerbosityLevel(Enum):
+    """ 
+    Enum class for setVerbosityLevel
+    """
+    VERBOSITY_ALL =0
+    VERBOSITY_INFO_WARNING_ERROR = 1
+    VERBOSITY_WARNING_ERROR = 2
+    VERBOSITY_ERROR = 3 
+    VERBOSITY_NONE = 4
+
 class Entity (object) :
     """
     This class binds dynamicgraph::Entity C++ class
@@ -72,6 +83,8 @@ class Entity (object) :
     """
     entities = dict ()
 
+
+    
     def __init__(self, className, instanceName):
         """
         Constructor: if not called by a child class, create and store a pointer
@@ -191,6 +204,7 @@ class Entity (object) :
                             "It is not advised to set a new attribute of the same name.")
         object.__setattr__(self, name, value)
 
+
     # --- COMMANDS BINDER -----------------------------------------------------
     # List of all the entity classes from the c++ factory, that have been bound
     # bind the py factory.
@@ -241,3 +255,25 @@ class Entity (object) :
         cmdList = filter(lambda x: not x in self.__class__.__dict__, cmdList)
         for cmd in cmdList:
             self.boundNewCommand( cmd )
+
+    def setLoggerVerbosityLevel(self, verbosity):
+        """ 
+        Specify for the entity the verbosity level
+        """
+        #return
+        wrap.entity_set_logger_verbosity(self.obj,verbosity)
+
+    def getLoggerVerbosityLevel(self):
+        """ 
+        Returns the entity's verbosity level
+        """
+        r=wrap.entity_get_logger_verbosity(self.obj)
+        if r==0:
+            return VerbosityLevel.VERBOSITY_ALL
+        elif r==1:
+            return VerbosityLevel.VERBOSITY_INFO_WARNING_ERROR
+        elif r==2:
+            return VerbosityLevel.VERBOSITY_WARNING_ERROR
+        elif r==3:
+            return VerbosityLevel.VERBOSITY_ERROR
+        return VerbosityLevel.VERBOSITY_NONE

--- a/src/dynamic_graph/entity.py
+++ b/src/dynamic_graph/entity.py
@@ -63,13 +63,13 @@ def updateEntityClasses(dictionary):
 
 from enum import Enum
 class VerbosityLevel(Enum):
-    """ 
+    """
     Enum class for setVerbosityLevel
     """
     VERBOSITY_ALL =0
     VERBOSITY_INFO_WARNING_ERROR = 1
     VERBOSITY_WARNING_ERROR = 2
-    VERBOSITY_ERROR = 3 
+    VERBOSITY_ERROR = 3
     VERBOSITY_NONE = 4
 
 class Entity (object) :
@@ -84,7 +84,7 @@ class Entity (object) :
     entities = dict ()
 
 
-    
+
     def __init__(self, className, instanceName):
         """
         Constructor: if not called by a child class, create and store a pointer
@@ -257,13 +257,13 @@ class Entity (object) :
             self.boundNewCommand( cmd )
 
     def setLoggerVerbosityLevel(self,verbosity):
-        """ 
+        """
         Specify for the entity the verbosity level
         """
         return wrap.entity_set_logger_verbosity(self.obj, verbosity)
 
     def getLoggerVerbosityLevel(self):
-        """ 
+        """
         Returns the entity's verbosity level
         """
         r=wrap.entity_get_logger_verbosity(self.obj)
@@ -276,3 +276,27 @@ class Entity (object) :
         elif r==3:
             return VerbosityLevel.VERBOSITY_ERROR
         return VerbosityLevel.VERBOSITY_NONE
+
+    def setTimeSample(self,timeSample):
+        """
+        Specify for the entity the time at which call is counted.
+        """
+        return wrap.entity_set_time_sample(self.obj, timeSample)
+
+    def getTimeSample(self):
+        """
+        Returns for the entity the time at which call is counted.
+        """
+        return wrap.entity_get_time_sample(self.obj)
+
+    def setStreamPrintPeriod(self,streamPrintPeriod):
+        """
+        Specify for the entity the period at which debugging information is printed
+        """
+        return wrap.entity_set_stream_print_period(self.obj, streamPrintPeriod)
+
+    def getStreamPrintPeriod(self):
+        """
+        Returns for the entity the period at which debugging information is printed
+        """
+        return wrap.entity_get_stream_print_period(self.obj)

--- a/src/dynamic_graph/entity.py
+++ b/src/dynamic_graph/entity.py
@@ -256,12 +256,11 @@ class Entity (object) :
         for cmd in cmdList:
             self.boundNewCommand( cmd )
 
-    def setLoggerVerbosityLevel(self, verbosity):
+    def setLoggerVerbosityLevel(self,verbosity):
         """ 
         Specify for the entity the verbosity level
         """
-        #return
-        wrap.entity_set_logger_verbosity(self.obj,verbosity)
+        return wrap.entity_set_logger_verbosity(self.obj, verbosity)
 
     def getLoggerVerbosityLevel(self):
         """ 

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -1,4 +1,3 @@
-
 // Copyright 2010, Florent Lamiraux, Thomas Moulard, LAAS-CNRS.
 //
 // This file is part of dynamic-graph-python.
@@ -415,6 +414,58 @@ namespace dynamicgraph {
 	return Py_BuildValue("s", oss.str().c_str());
       }
 
+      /**
+	 \brief Set verbosity Level
+      */
+      PyObject* setLoggerVerbosityLevel(PyObject* /*self*/, PyObject*  args )
+      {
+
+	PyObject* object = NULL;
+	PyObject* objectVerbosityLevel = NULL;
+	if (!PyArg_ParseTuple(args, "OO", &object,&objectVerbosityLevel))
+	  return NULL;
+
+	// Retrieve the entity instance
+	  if (!PyCObject_Check(object)) {
+	    PyErr_SetString(PyExc_TypeError,
+			    "First argument should be an object");
+	    return NULL;
+	  }
+
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	// Retrieve object verbosity level
+	PyObject* valueOfVerbosityLevel = PyObject_GetAttrString(objectVerbosityLevel, "value");
+	long verbosityLevel = PyLong_AsLong(valueOfVerbosityLevel);//*((int*) lpointer);
+
+	try {
+	  switch(verbosityLevel)
+	    {
+	    case 0: entity->setLoggerVerbosityLevel(VERBOSITY_ALL);
+	      break;
+	    case 1: entity->setLoggerVerbosityLevel(VERBOSITY_INFO_WARNING_ERROR);
+	      break;
+	    case 2: entity->setLoggerVerbosityLevel(VERBOSITY_WARNING_ERROR);
+	      break;
+	    case 3: entity->setLoggerVerbosityLevel(VERBOSITY_ERROR);
+	      break;
+	    default: entity->setLoggerVerbosityLevel(VERBOSITY_NONE);
+	      break;
+	    }
+	} catch (const std::exception& exc) {
+	  PyErr_SetString(dgpyError, exc.what());
+	  return NULL;
+	} catch (const char* s) {
+	    PyErr_SetString(dgpyError, s);
+	    return NULL;
+	} catch (...) {
+	    PyErr_SetString(dgpyError, "Unknown exception");
+	    return NULL;
+	}
+
+	return Py_BuildValue("");
+      }
 
       /**
 	 \brief Get verbosity Level
@@ -431,7 +482,7 @@ namespace dynamicgraph {
 			  "first argument is not an object");
 	  return NULL;
 	}
-	
+
 	void *pointer = PyCObject_AsVoidPtr(object);
 	Entity* entity = (Entity*)pointer;
 
@@ -444,58 +495,6 @@ namespace dynamicgraph {
 	return Py_BuildValue("i",ares);
       }
 
-            /**
-	 \brief Set verbosity Level
-      */
-      PyObject* setLoggerVerbosityLevel(PyObject* /*self*/, PyObject*  /* args */)
-      {
-#if 0	
-	PyObject* object = NULL;
-	PyObject* objectVerbosityLevel = NULL;
-	if (!PyArg_ParseTuple(args, "OO", &object,&objectVerbosityLevel))
-	  return NULL;
-	
-	// Retrieve the entity instance
-	  if (!PyCObject_Check(object)) {
-	    PyErr_SetString(PyExc_TypeError,
-			    "First argument should be an object");
-	    return NULL;
-	  }
-	
-	void *pointer = PyCObject_AsVoidPtr(object);
-	Entity* entity = (Entity*)pointer;
-	
-	// Retrieve object verbosity level
-	PyObject* valueOfVerbosityLevel = PyObject_GetAttrString(objectVerbosityLevel, "value");
-	long verbosityLevel = PyLong_AsLong(valueOfVerbosityLevel);//*((int*) lpointer);
-	
-	try {
-	  switch(verbosityLevel)
-	    {
-	    case 0: entity->setLoggerVerbosityLevel(VERBOSITY_ALL);
-	      break;
-	    case 1: entity->setLoggerVerbosityLevel(VERBOSITY_INFO_WARNING_ERROR);
-	      break;
-	    case 2: entity->setLoggerVerbosityLevel(VERBOSITY_WARNING_ERROR);
-	      break;
-	    case 3: entity->setLoggerVerbosityLevel(VERBOSITY_ERROR);
-	      break;
-	    default: entity->setLoggerVerbosityLevel(VERBOSITY_NONE);
-	      break;
-	    }	  
-	} catch (const std::exception& exc) {							
-	  PyErr_SetString(dgpyError, exc.what());		
-	  return NULL;					
-	} catch (const char* s) {							
-	    PyErr_SetString(dgpyError, s);			
-	    return NULL;					
-	} catch (...) {					
-	    PyErr_SetString(dgpyError, "Unknown exception");	
-	    return NULL;						
-	}
-#endif
-	return NULL;
-      }
 
     }
   }

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -1,3 +1,4 @@
+
 // Copyright 2010, Florent Lamiraux, Thomas Moulard, LAAS-CNRS.
 //
 // This file is part of dynamic-graph-python.
@@ -413,6 +414,89 @@ namespace dynamicgraph {
 	/* Return the resulting string. */
 	return Py_BuildValue("s", oss.str().c_str());
       }
+
+
+      /**
+	 \brief Get verbosity Level
+      */
+      PyObject* getLoggerVerbosityLevel(PyObject* /*self*/, PyObject* args)
+      {
+	PyObject* object = NULL;
+	if (!PyArg_ParseTuple(args, "O", &object))
+	  return NULL;
+
+	// Retrieve the entity instance
+	if (!PyCObject_Check(object)) {
+	  PyErr_SetString(PyExc_TypeError,
+			  "first argument is not an object");
+	  return NULL;
+	}
+	
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	LoggerVerbosity alv ;
+	try {
+	  alv = entity->getLoggerVerbosityLevel();
+	} CATCH_ALL_EXCEPTIONS();
+
+	int ares= (int)alv;
+	return Py_BuildValue("i",ares);
+      }
+
+            /**
+	 \brief Set verbosity Level
+      */
+      PyObject* setLoggerVerbosityLevel(PyObject* /*self*/, PyObject*  /* args */)
+      {
+#if 0	
+	PyObject* object = NULL;
+	PyObject* objectVerbosityLevel = NULL;
+	if (!PyArg_ParseTuple(args, "OO", &object,&objectVerbosityLevel))
+	  return NULL;
+	
+	// Retrieve the entity instance
+	  if (!PyCObject_Check(object)) {
+	    PyErr_SetString(PyExc_TypeError,
+			    "First argument should be an object");
+	    return NULL;
+	  }
+	
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+	
+	// Retrieve object verbosity level
+	PyObject* valueOfVerbosityLevel = PyObject_GetAttrString(objectVerbosityLevel, "value");
+	long verbosityLevel = PyLong_AsLong(valueOfVerbosityLevel);//*((int*) lpointer);
+	
+	try {
+	  switch(verbosityLevel)
+	    {
+	    case 0: entity->setLoggerVerbosityLevel(VERBOSITY_ALL);
+	      break;
+	    case 1: entity->setLoggerVerbosityLevel(VERBOSITY_INFO_WARNING_ERROR);
+	      break;
+	    case 2: entity->setLoggerVerbosityLevel(VERBOSITY_WARNING_ERROR);
+	      break;
+	    case 3: entity->setLoggerVerbosityLevel(VERBOSITY_ERROR);
+	      break;
+	    default: entity->setLoggerVerbosityLevel(VERBOSITY_NONE);
+	      break;
+	    }	  
+	} catch (const std::exception& exc) {							
+	  PyErr_SetString(dgpyError, exc.what());		
+	  return NULL;					
+	} catch (const char* s) {							
+	    PyErr_SetString(dgpyError, s);			
+	    return NULL;					
+	} catch (...) {					
+	    PyErr_SetString(dgpyError, "Unknown exception");	
+	    return NULL;						
+	}
+#endif
+	return NULL;
+      }
+
     }
   }
 }

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -437,7 +437,7 @@ namespace dynamicgraph {
 
 	// Retrieve object verbosity level
 	PyObject* valueOfVerbosityLevel = PyObject_GetAttrString(objectVerbosityLevel, "value");
-	long verbosityLevel = PyLong_AsLong(valueOfVerbosityLevel);//*((int*) lpointer);
+	long verbosityLevel = PyLong_AsLong(valueOfVerbosityLevel);
 
 	try {
 	  switch(verbosityLevel)
@@ -457,11 +457,11 @@ namespace dynamicgraph {
 	  PyErr_SetString(dgpyError, exc.what());
 	  return NULL;
 	} catch (const char* s) {
-	    PyErr_SetString(dgpyError, s);
-	    return NULL;
+	  PyErr_SetString(dgpyError, s);
+	  return NULL;
 	} catch (...) {
-	    PyErr_SetString(dgpyError, "Unknown exception");
-	    return NULL;
+	  PyErr_SetString(dgpyError, "Unknown exception");
+	  return NULL;
 	}
 
 	return Py_BuildValue("");
@@ -493,6 +493,136 @@ namespace dynamicgraph {
 
 	int ares= (int)alv;
 	return Py_BuildValue("i",ares);
+      }
+
+      /**
+	 \brief Get stream print period
+      */
+      PyObject* getStreamPrintPeriod(PyObject* /*self*/, PyObject* args)
+      {
+	PyObject* object = NULL;
+	if (!PyArg_ParseTuple(args, "O", &object))
+	  return NULL;
+
+	// Retrieve the entity instance
+	if (!PyCObject_Check(object)) {
+	  PyErr_SetString(PyExc_TypeError,
+			  "first argument is not an object");
+	  return NULL;
+	}
+
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	double r ;
+	try {
+	  r = entity->getStreamPrintPeriod();
+	} CATCH_ALL_EXCEPTIONS();
+
+	return Py_BuildValue("d",r);
+      }
+
+      /**
+	 \brief Set print period
+      */
+      PyObject* setStreamPrintPeriod(PyObject* /*self*/, PyObject*  args )
+      {
+
+	PyObject* object = NULL;
+	double streamPrintPeriod=0;
+	if (!PyArg_ParseTuple(args, "Od", &object,&streamPrintPeriod))
+	  return NULL;
+
+	// Retrieve the entity instance
+	  if (!PyCObject_Check(object)) {
+	    PyErr_SetString(PyExc_TypeError,
+			    "First argument should be an object");
+	    return NULL;
+	  }
+
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	try {
+	  entity->setStreamPrintPeriod(streamPrintPeriod);
+
+	} catch (const std::exception& exc) {
+	  PyErr_SetString(dgpyError, exc.what());
+	  return NULL;
+	} catch (const char* s) {
+	  PyErr_SetString(dgpyError, s);
+	  return NULL;
+	} catch (...) {
+	  PyErr_SetString(dgpyError, "Unknown exception");
+	  return NULL;
+	}
+
+	return Py_BuildValue("");
+      }
+
+      /**
+	 \brief Get stream print period
+      */
+      PyObject* getTimeSample(PyObject* /*self*/, PyObject* args)
+      {
+	PyObject* object = NULL;
+	if (!PyArg_ParseTuple(args, "O", &object))
+	  return NULL;
+
+	// Retrieve the entity instance
+	if (!PyCObject_Check(object)) {
+	  PyErr_SetString(PyExc_TypeError,
+			  "first argument is not an object");
+	  return NULL;
+	}
+
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	double r ;
+	try {
+	  r = entity->getTimeSample();
+	} CATCH_ALL_EXCEPTIONS();
+
+	return Py_BuildValue("d",r);
+      }
+
+      /**
+	 \brief Set time sample
+      */
+      PyObject* setTimeSample(PyObject* /*self*/, PyObject*  args )
+      {
+
+	PyObject* object = NULL;
+	double timeSample;
+	if (!PyArg_ParseTuple(args, "Od", &object,&timeSample))
+	  return NULL;
+
+	// Retrieve the entity instance
+	  if (!PyCObject_Check(object)) {
+	    PyErr_SetString(PyExc_TypeError,
+			    "First argument should be an object");
+	    return NULL;
+	  }
+
+	void *pointer = PyCObject_AsVoidPtr(object);
+	Entity* entity = (Entity*)pointer;
+
+	try {
+	  entity->setTimeSample(timeSample);
+
+	} catch (const std::exception& exc) {
+	  PyErr_SetString(dgpyError, exc.what());
+	  return NULL;
+	} catch (const char* s) {
+	  PyErr_SetString(dgpyError, s);
+	  return NULL;
+	} catch (...) {
+	  PyErr_SetString(dgpyError, "Unknown exception");
+	  return NULL;
+	}
+
+	return Py_BuildValue("");
       }
 
 

--- a/src/entity-py.cc
+++ b/src/entity-py.cc
@@ -450,6 +450,8 @@ namespace dynamicgraph {
 	      break;
 	    case 3: entity->setLoggerVerbosityLevel(VERBOSITY_ERROR);
 	      break;
+	    case 4:  entity->setLoggerVerbosityLevel(VERBOSITY_NONE);
+	      break;
 	    default: entity->setLoggerVerbosityLevel(VERBOSITY_NONE);
 	      break;
 	    }

--- a/src/pool-py.cc
+++ b/src/pool-py.cc
@@ -24,6 +24,7 @@ namespace dynamicgraph {
 
     extern PyObject* dgpyError;
     namespace pool {
+
       PyObject* writeGraph (PyObject* /*self*/, PyObject* args)
       {
 	char* filename;
@@ -52,16 +53,16 @@ namespace dynamicgraph {
 	  Py_ssize_t classNumber = listOfEntities.size();
 	  // Build a tuple object
 	  PyObject* classTuple = PyTuple_New(classNumber);
-	  
+
 	  Py_ssize_t iEntity = 0;
-	  for (PoolStorage::Entities::const_iterator entity_it = 
+	  for (PoolStorage::Entities::const_iterator entity_it =
 		 listOfEntities.begin();
 	       entity_it != listOfEntities.end();
 	       ++entity_it)
 	    {
 	      const std::string & aname = entity_it->second->getName();
-	      
-	      PyObject* className = 
+
+	      PyObject* className =
 		Py_BuildValue("s", aname.c_str());
 	      PyTuple_SetItem(classTuple, iEntity, className);
 	      iEntity++;
@@ -71,6 +72,7 @@ namespace dynamicgraph {
 	return NULL;
       }
 
+
     } // python
-  } // dynamicgraph
-} // namespace pool
+  } // namespace pool
+} // dynamicgraph

--- a/unitTesting/CMakeLists.txt
+++ b/unitTesting/CMakeLists.txt
@@ -9,7 +9,6 @@ INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
 INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
 LINK_DIRECTORIES(${Boost_LIBRARY_DIRS} ${PYTHON_LIBRARY_DIRS})
 
-
 ADD_DEFINITIONS(-DDEBUG=2)
 
 # provide path to library libdynamic-graph.so
@@ -45,6 +44,65 @@ ADD_CUSTOM_COMMAND(TARGET interpreter-test-runfile POST_BUILD
   ${CMAKE_BINARY_DIR}/unitTesting
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/unitTesting/test_python-restart_interpreter.py
   ${CMAKE_BINARY_DIR}/unitTesting
-
 )
+
+#### Build entity library ####
+set(LIBRARY_NAME custom_entity)
+ADD_LIBRARY(${LIBRARY_NAME} SHARED ${LIBRARY_NAME}.cpp)
+
+#remove the "lib" prefix from the publig output name
+SET_TARGET_PROPERTIES(${LIBRARY_NAME} PROPERTIES PREFIX "")
+
+SET_TARGET_PROPERTIES(${LIBRARY_NAME}
+  PROPERTIES
+  SOVERSION ${PROJECT_VERSION}
+  INSTALL_RPATH ${DYNAMIC_GRAPH_PLUGINDIR})
+
+#add_dependencies(${LIBRARY_NAME} dynamic-graph)
+target_link_libraries(${LIBRARY_NAME} dynamic-graph)
+
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} dynamic-graph)
+
+STRING(REPLACE - _ PYTHON_LIBRARY_NAME ${LIBRARY_NAME})
+MESSAGE(STATUS "dynamic_graph_plugindir: ${DYNAMIC_GRAPH_PLUGINDIR}")
+
+
+# Generates a local module in unitTesting
+FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/dynamic_graph_tests/${LIBRARY_NAME}")
+CONFIGURE_FILE(
+  ${PROJECT_SOURCE_DIR}/cmake/dynamic_graph/submodule/__init__.py.cmake
+  ${PROJECT_BINARY_DIR}/unitTesting/dynamic_graph_tests/${LIBRARY_NAME}/__init__.py
+  )
+FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dynamic_graph_tests/__init__.py
+  "")
+
+# Generates a local wrap.so library
+
+SET(SOURCE_PYTHON_MODULE "cmake/dynamic_graph/python-module-py.cc")
+
+SET(PYTHON_MODULE   ${PYTHON_LIBRARY_NAME}-wrap)
+CMAKE_POLICY(PUSH)
+IF(POLICY CMP0037)
+  CMAKE_POLICY(SET CMP0037 OLD)
+ENDIF()
+
+ADD_LIBRARY(${PYTHON_MODULE}
+  MODULE
+  ${PROJECT_SOURCE_DIR}/${SOURCE_PYTHON_MODULE})
+
+SET_TARGET_PROPERTIES(${PYTHON_MODULE}
+  PROPERTIES PREFIX ""
+  OUTPUT_NAME dynamic_graph_tests/${LIBRARY_NAME}/wrap
+  )
+
+CMAKE_POLICY(POP)
+
+TARGET_LINK_LIBRARIES(${PYTHON_MODULE} ${PUBLIC_KEYWORD} "-Wl,--no-as-needed")
+TARGET_LINK_LIBRARIES(${PYTHON_MODULE} ${PUBLIC_KEYWORD} ${LIBRARY_NAME} ${PYTHON_LIBRARY})
+
+INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+
+FILE(COPY
+  ${CMAKE_SOURCE_DIR}/unitTesting/test_custom_entity.py DESTINATION
+  ${CMAKE_BINARY_DIR}/unitTesting/ )
 

--- a/unitTesting/custom_entity.cpp
+++ b/unitTesting/custom_entity.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2010-2019 LAAS, CNRS
+ * Thomas Moulard.
+ *
+ */
+
+#define ENABLE_RT_LOG
+
+#include <sstream>
+#include <dynamic-graph/entity.h>
+#include <dynamic-graph/exception-factory.h>
+#include "dynamic-graph/factory.h"
+#include "dynamic-graph/pool.h"
+#include <dynamic-graph/real-time-logger.h>
+#include <dynamic-graph/signal-ptr.h>
+#include <dynamic-graph/signal-time-dependent.h>
+
+
+namespace dynamicgraph
+{
+  class CustomEntity : public Entity
+  {
+  public:
+    dynamicgraph::SignalPtr<double, int> m_sigdSIN;
+    dynamicgraph::SignalTimeDependent<double, int> m_sigdTimeDepSOUT;
+
+    static const std::string CLASS_NAME;
+    virtual const std::string& getClassName () const
+    {
+      return CLASS_NAME;
+    }
+    CustomEntity (const std::string n)
+      : Entity (n)
+      ,m_sigdSIN(NULL,"CustomEntity("+name+")::input(double)::in_double")
+      ,m_sigdTimeDepSOUT(boost::bind(&CustomEntity::update,this,_1,_2),
+			 m_sigdSIN,
+			 "CustomEntity("+name+")::input(double)::out_double")
+
+    {
+    }
+
+    void addSignal()
+    {
+      signalRegistration(m_sigdSIN << m_sigdTimeDepSOUT);
+    }
+
+    void rmValidSignal()
+    {
+      signalDeregistration("in_double");
+      signalDeregistration("out_double");
+    }
+
+    double & update(double &res, const int &inTime)
+    {
+      const double &aDouble = m_sigdSIN(inTime);
+      res = aDouble;
+      return res;
+    }
+
+  };
+  DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN (CustomEntity,"CustomEntity");
+}

--- a/unitTesting/custom_entity.cpp
+++ b/unitTesting/custom_entity.cpp
@@ -57,15 +57,24 @@ namespace dynamicgraph
       std::ostringstream oss;
       oss << "start update " << res;
       sendMsg(oss.str().c_str(),MSG_TYPE_ERROR);
-      sendMsg("This is a message of level MSG_TYPE_DEBUG",MSG_TYPE_DEBUG);
-      sendMsg("This is a message of level MSG_TYPE_INFO",MSG_TYPE_INFO);
-      sendMsg("This is a message of level MSG_TYPE_WARNING",MSG_TYPE_WARNING);
-      sendMsg("This is a message of level MSG_TYPE_ERROR",MSG_TYPE_ERROR);
-      sendMsg("This is a message of level MSG_TYPE_DEBUG_STREAM",MSG_TYPE_DEBUG_STREAM);
-      sendMsg("This is a message of level MSG_TYPE_INFO_STREAM",MSG_TYPE_INFO_STREAM);
-      sendMsg("This is a message of level MSG_TYPE_WARNING_STREAM",MSG_TYPE_WARNING_STREAM);
-      sendMsg("This is a message of level MSG_TYPE_ERROR_STREAM",MSG_TYPE_ERROR_STREAM);
-      sendMsg("end update",MSG_TYPE_ERROR);
+      sendMsg("This is a message of level MSG_TYPE_DEBUG",
+	      MSG_TYPE_DEBUG,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_INFO",
+	      MSG_TYPE_INFO,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_WARNING",
+	      MSG_TYPE_WARNING,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_ERROR",
+	      MSG_TYPE_ERROR,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_DEBUG_STREAM",
+	      MSG_TYPE_DEBUG_STREAM,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_INFO_STREAM",
+	      MSG_TYPE_INFO_STREAM,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_WARNING_STREAM",
+	      MSG_TYPE_WARNING_STREAM,__FILE__,__LINE__);
+      sendMsg("This is a message of level MSG_TYPE_ERROR_STREAM",
+	      MSG_TYPE_ERROR_STREAM,__FILE__,__LINE__);
+      sendMsg("end update",
+	      MSG_TYPE_ERROR,__FILE__,__LINE__);
       return res;
     }
 

--- a/unitTesting/custom_entity.cpp
+++ b/unitTesting/custom_entity.cpp
@@ -36,6 +36,7 @@ namespace dynamicgraph
 			 "CustomEntity("+name+")::input(double)::out_double")
 
     {
+      addSignal();
     }
 
     void addSignal()
@@ -53,6 +54,18 @@ namespace dynamicgraph
     {
       const double &aDouble = m_sigdSIN(inTime);
       res = aDouble;
+      std::ostringstream oss;
+      oss << "start update " << res;
+      sendMsg(oss.str().c_str(),MSG_TYPE_ERROR);
+      sendMsg("This is a message of level MSG_TYPE_DEBUG",MSG_TYPE_DEBUG);
+      sendMsg("This is a message of level MSG_TYPE_INFO",MSG_TYPE_INFO);
+      sendMsg("This is a message of level MSG_TYPE_WARNING",MSG_TYPE_WARNING);
+      sendMsg("This is a message of level MSG_TYPE_ERROR",MSG_TYPE_ERROR);
+      sendMsg("This is a message of level MSG_TYPE_DEBUG_STREAM",MSG_TYPE_DEBUG_STREAM);
+      sendMsg("This is a message of level MSG_TYPE_INFO_STREAM",MSG_TYPE_INFO_STREAM);
+      sendMsg("This is a message of level MSG_TYPE_WARNING_STREAM",MSG_TYPE_WARNING_STREAM);
+      sendMsg("This is a message of level MSG_TYPE_ERROR_STREAM",MSG_TYPE_ERROR_STREAM);
+      sendMsg("end update",MSG_TYPE_ERROR);
       return res;
     }
 

--- a/unitTesting/test_custom_entity.py
+++ b/unitTesting/test_custom_entity.py
@@ -1,7 +1,9 @@
 # Olivier Stasse
 # 2019 CNRS
-# 
+#
 import sys, os
+import time
+
 # Put local python module at first priority
 sys.path.insert(0,os.getcwd()+'/../src')
 sys.path.insert(0,os.getcwd())
@@ -9,18 +11,63 @@ sys.path.insert(0,os.getcwd())
 print(os.getcwd())
 from dynamic_graph_tests.custom_entity import *
 from dynamic_graph.entity import VerbosityLevel
+from dynamic_graph import addLoggerFileOutputStream, addLoggerCoutOutputStream, closeLoggerFileOutputStream
+from dynamic_graph import real_time_logger_instance, real_time_logger_spin_once, real_time_logger_destroy
+
+# Starts the real time logger instance
+real_time_logger_instance()
 
 aCustomEntity = CustomEntity("a_custom_entity")
-print(dir(aCustomEntity))
+
+addLoggerFileOutputStream("/tmp/output.dat")
 aCustomEntity.signals()
+
+aCustomEntity.setTimeSample(0.001)
+print(aCustomEntity.getTimeSample())
+aCustomEntity.setStreamPrintPeriod(0.002)
+print(aCustomEntity.getStreamPrintPeriod())
+
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_INFO_WARNING_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
+for i in range(0,5):
+    aCustomEntity.in_double.value=i
+    aCustomEntity.out_double.recompute(i)
+    real_time_logger_spin_once()
+    print(i)
+
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_WARNING_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
+for i in range(5,10):
+    aCustomEntity.in_double.value=i
+    aCustomEntity.out_double.recompute(i)
+    real_time_logger_spin_once()
+
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
+for i in range(10,15):
+    aCustomEntity.in_double.value=i
+    aCustomEntity.out_double.recompute(i)
+    real_time_logger_spin_once()
+
+addLoggerCoutOutputStream()
+
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_NONE)
 print(aCustomEntity.getLoggerVerbosityLevel())
+for i in range(15,20):
+    aCustomEntity.in_double.value=i
+    aCustomEntity.out_double.recompute(i)
+    real_time_logger_spin_once()
+
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ALL)
 print(aCustomEntity.getLoggerVerbosityLevel())
+for i in range(20,25):
+    aCustomEntity.in_double.value=i
+    aCustomEntity.out_double.recompute(i)
+    real_time_logger_spin_once()
 
+
+# End the real time logger
+real_time_logger_destroy()
+
+# Close all the output stream
+closeLoggerFileOutputStream()

--- a/unitTesting/test_custom_entity.py
+++ b/unitTesting/test_custom_entity.py
@@ -15,7 +15,6 @@ from dynamic_graph import addLoggerFileOutputStream, addLoggerCoutOutputStream, 
 from dynamic_graph import real_time_logger_instance, real_time_logger_spin_once, real_time_logger_destroy
 
 # Starts the real time logger instance
-real_time_logger_instance()
 
 aCustomEntity = CustomEntity("a_custom_entity")
 
@@ -34,6 +33,7 @@ for i in range(0,5):
     aCustomEntity.out_double.recompute(i)
     real_time_logger_spin_once()
     print(i)
+time.sleep(1)
 
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_WARNING_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
@@ -41,6 +41,7 @@ for i in range(5,10):
     aCustomEntity.in_double.value=i
     aCustomEntity.out_double.recompute(i)
     real_time_logger_spin_once()
+time.sleep(1)
 
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
@@ -48,15 +49,16 @@ for i in range(10,15):
     aCustomEntity.in_double.value=i
     aCustomEntity.out_double.recompute(i)
     real_time_logger_spin_once()
-
+time.sleep(1)
 addLoggerCoutOutputStream()
-
+time.sleep(1)
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_NONE)
 print(aCustomEntity.getLoggerVerbosityLevel())
 for i in range(15,20):
     aCustomEntity.in_double.value=i
     aCustomEntity.out_double.recompute(i)
     real_time_logger_spin_once()
+time.sleep(1)
 
 aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ALL)
 print(aCustomEntity.getLoggerVerbosityLevel())
@@ -71,3 +73,4 @@ real_time_logger_destroy()
 
 # Close all the output stream
 closeLoggerFileOutputStream()
+

--- a/unitTesting/test_custom_entity.py
+++ b/unitTesting/test_custom_entity.py
@@ -1,3 +1,6 @@
+# Olivier Stasse
+# 2019 CNRS
+# 
 import sys, os
 # Put local python module at first priority
 sys.path.insert(0,os.getcwd()+'/../src')
@@ -8,11 +11,16 @@ from dynamic_graph_tests.custom_entity import *
 from dynamic_graph.entity import VerbosityLevel
 
 aCustomEntity = CustomEntity("a_custom_entity")
-
-aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_WARNING_ERROR)
-
-
-
+print(dir(aCustomEntity))
+aCustomEntity.signals()
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_INFO_WARNING_ERROR)
 print(aCustomEntity.getLoggerVerbosityLevel())
-
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_WARNING_ERROR)
+print(aCustomEntity.getLoggerVerbosityLevel())
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ERROR)
+print(aCustomEntity.getLoggerVerbosityLevel())
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_NONE)
+print(aCustomEntity.getLoggerVerbosityLevel())
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_ALL)
+print(aCustomEntity.getLoggerVerbosityLevel())
 

--- a/unitTesting/test_custom_entity.py
+++ b/unitTesting/test_custom_entity.py
@@ -1,0 +1,18 @@
+import sys, os
+# Put local python module at first priority
+sys.path.insert(0,os.getcwd()+'/../src')
+sys.path.insert(0,os.getcwd())
+
+print(os.getcwd())
+from dynamic_graph_tests.custom_entity import *
+from dynamic_graph.entity import VerbosityLevel
+
+aCustomEntity = CustomEntity("a_custom_entity")
+
+aCustomEntity.setLoggerVerbosityLevel(VerbosityLevel.VERBOSITY_WARNING_ERROR)
+
+
+
+print(aCustomEntity.getLoggerVerbosityLevel())
+
+


### PR DESCRIPTION
This PR is coupled with the one proposed on dynamic-graph https://github.com/stack-of-tasks/dynamic-graph/pull/41
It proposes python bindings to set/getTimeSample and set/getStreamPrintPeriod for an entity.
It also provides bindings to access the singleton real-time-logger.