### PR TITLE
Define a variable to detect that the python interpreter is remote

### DIFF
--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -47,7 +47,8 @@ static const std::string pythonPrefix[5] = {
   "        return s\n"
   "stdout_catcher = StdoutCatcher()\n"
   "import sys\n"
-  "sys.stdout = stdout_catcher"
+  "sys.stdout = stdout_catcher\n"
+  "dynamic_graph_remote_interpreter = True"
 };
 }
 }

--- a/unitTesting/interpreter-test.cc
+++ b/unitTesting/interpreter-test.cc
@@ -20,6 +20,13 @@ int main(int argc, char ** argv)
     interp.python("print \"I am the interpreter\"", result, out, err);
     //incorrect input
     interp.python("print I am the interpreter", result, out, err);
+    // Test that variable dynamic_graph_remote_interpreter is set to True
+    interp.python("globals ().has_key (\"dynamic_graph_remote_interpreter\")",
+                  result, out, err);
+    if (result != "True") return -1;
+    interp.python("dynamic_graph_remote_interpreter",
+                  result, out, err);
+    if (result != "True") return -1;
   }
   return 0;
 }

--- a/unitTesting/interpreter-test.cc
+++ b/unitTesting/interpreter-test.cc
@@ -17,7 +17,7 @@ int main(int argc, char ** argv)
   for (int i=0; i<numTest; ++i)
   {
     //correct input
-    interp.python("print \"I am the interpreter\"", result, out, err);
+    interp.python("print (\"I am the interpreter\")", result, out, err);
     //incorrect input
     interp.python("print I am the interpreter", result, out, err);
     // Test that variable dynamic_graph_remote_interpreter is set to True


### PR DESCRIPTION
This PR defines variable "dynamic_graph_remote_interpreter" in the remote python interpreter.
The goal is to allow users to know whether they are using a remote interpreter or not.
