### PR TITLE
Fix issue with roscpp

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <depend>dynamic-graph</depend>
-  <depend>roscpp</depend>
   <depend>boost</depend>
   
   <buildtool_depend>cmake</buildtool_depend>


### PR DESCRIPTION
Remove the roscpp dependency because it is causing issues with the release of the package on ROS2 and after discussion with @olivier-stasse , it was not relevant to be there. 