### PR TITLE
add missing include for Boost 1.76

### DIFF
--- a/include/dynamic-graph/python/module.hh
+++ b/include/dynamic-graph/python/module.hh
@@ -8,6 +8,7 @@
 
 #include <boost/python.hpp>
 #include <boost/mpl/for_each.hpp>
+#include <boost/mpl/vector.hpp>
 
 #include <dynamic-graph/entity.h>
 #include <dynamic-graph/python/dynamic-graph-py.hh>


### PR DESCRIPTION
fix:
```
Dans le fichier inclus depuis …/dynamic-graph-python/build/tests/python-module-py.cc:18:
…/dynamic-graph-python/tests/custom_entity_module.h:3:21: erreur: « vector » dans l'espace de noms « boost::mpl » ne nomme pas un type de patron; vouliez-vous employer « vector9 » ?
    3 | typedef boost::mpl::vector<dynamicgraph::CustomEntity> entities_t;
      |                     ^~~~~~
      |                     vector9
…/dynamic-graph-python/build/tests/python-module-py.cc: Dans la fonction « void init_module_wrap() »:
…/dynamic-graph-python/build/tests/python-module-py.cc:31:24: erreur: « entities_t » n'a pas été déclaré dans cette portée
   31 |   boost::mpl::for_each<entities_t, boost::type<boost::mpl::_> >(register_entity());
      |                        ^~~~~~~~~~
…/build/tests/python-module-py.cc:31:64: erreur: pas de fonction correspondant à l'appel « for_each<<expression error>, boost::type<mpl_::arg<-1> > >(register_entity) »
   31 |   boost::mpl::for_each<entities_t, boost::type<boost::mpl::_> >(register_entity());
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis /usr/include/boost/python/object/class_metadata.hpp:30,
                 depuis /usr/include/boost/python/class.hpp:23,
                 depuis /usr/include/boost/python.hpp:18,
                 depuis …/dynamic-graph-python/include/dynamic-graph/python/module.hh:9,
                 depuis …/dynamic-graph-python/build/tests/python-module-py.cc:16:
/usr/include/boost/mpl/for_each.hpp:97:6: note: candidat : « template<class Sequence, class TransformOp, class F> void boost::mpl::for_each(F, Sequence*, TransformOp*) »
   97 | void for_each(F f, Sequence* = 0, TransformOp* = 0)
      |      ^~~~~~~~
/usr/include/boost/mpl/for_each.hpp:97:6: note:   la déduction/substitution de l'argument du patron a échoué:
…/dynamic-graph-python/build/tests/python-module-py.cc:31:64: erreur: l'argument 1 du patron est invalide
   31 |   boost::mpl::for_each<entities_t, boost::type<boost::mpl::_> >(register_entity());
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis /usr/include/boost/python/object/class_metadata.hpp:30,
                 depuis /usr/include/boost/python/class.hpp:23,
                 depuis /usr/include/boost/python.hpp:18,
                 depuis …/dynamic-graph-python/include/dynamic-graph/python/module.hh:9,
                 depuis …/dynamic-graph-python/build/tests/python-module-py.cc:16:
/usr/include/boost/mpl/for_each.hpp:114:6: note: candidat : « template<class Sequence, class F> void boost::mpl::for_each(F, Sequence*) »
  114 | void for_each(F f, Sequence* = 0)
      |      ^~~~~~~~
/usr/include/boost/mpl/for_each.hpp:114:6: note:   la déduction/substitution de l'argument du patron a échoué:
…/dynamic-graph-python/build/tests/python-module-py.cc:31:64: erreur: l'argument 1 du patron est invalide
   31 |   boost::mpl::for_each<entities_t, boost::type<boost::mpl::_> >(register_entity());
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```