### PR TITLE
interpreter: fix deprecation for python 3.9

### DIFF
--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -69,7 +69,9 @@ Interpreter::Interpreter() {
   dlopen(PYTHON_LIBRARY, RTLD_LAZY | RTLD_GLOBAL);
 #endif
   Py_Initialize();
+#if PY_MAJOR_VERSION < 3 || PY_MINOR_VERSION < 7
   PyEval_InitThreads();
+#endif
   mainmod_ = PyImport_AddModule("__main__");
   Py_INCREF(mainmod_);
   globals_ = PyModule_GetDict(mainmod_);


### PR DESCRIPTION
ref. https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads:

> Changed in version 3.7: This function is now called by Py_Initialize(),
> so you don’t have to call it yourself anymore.

> Changed in version 3.9: The function now does nothing.

> Deprecated since version 3.9, will be removed in version 3.11.