### PR TITLE
Bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ set(DOXYGEN_USE_MATHJAX YES)
 # JRL-cmakemodule setup
 include(cmake/base.cmake)
 include(cmake/boost.cmake)
-include(cmake/python.cmake)
 
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2010-2020, Florent Lamiraux, Thomas Moulard, Olivier Stasse, Guilhem
 # Saurel, JRL, CNRS/AIST, LAAS-CNRS
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 # Project properties
 set(PROJECT_ORG stack-of-tasks)
@@ -21,6 +21,7 @@ set(DOXYGEN_USE_MATHJAX YES)
 # JRL-cmakemodule setup
 include(cmake/base.cmake)
 include(cmake/boost.cmake)
+include(cmake/python.cmake)
 
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)

--- a/include/dynamic-graph/python/interpreter.hh
+++ b/include/dynamic-graph/python/interpreter.hh
@@ -51,8 +51,6 @@ class DYNAMIC_GRAPH_PYTHON_DLLAPI Interpreter {
   PyThreadState* _pyState;
   /// Pointer to the dictionary of global variables
   PyObject* globals_;
-  /// Pointer to the dictionary of local variables
-  PyObject* locals_;
   PyObject* mainmod_;
 };
 }  // namespace python

--- a/src/dynamic_graph/convert-dg-to-py.cc
+++ b/src/dynamic_graph/convert-dg-to-py.cc
@@ -8,6 +8,7 @@
 
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 

--- a/src/dynamic_graph/convert-dg-to-py.cc
+++ b/src/dynamic_graph/convert-dg-to-py.cc
@@ -30,11 +30,11 @@ command::Value toValue(bp::object o, const command::Value::Type& valueType) {
     case (Value::UNSIGNED):
       return Value(bp::extract<unsigned>(o));
     case (Value::UNSIGNEDLONGINT):
-      return Value(bp::extract<unsigned long int>(o));
+      return Value(bp::extract<std::uint64_t>(o));
     case (Value::INT):
       return Value(bp::extract<int>(o));
     case (Value::LONGINT):
-      return Value(bp::extract<long int>(o));
+      return Value(bp::extract<std::int64_t>(o));
     case (Value::FLOAT):
       return Value(bp::extract<float>(o));
     case (Value::DOUBLE):

--- a/src/dynamic_graph/entity-py.cc
+++ b/src/dynamic_graph/entity-py.cc
@@ -83,8 +83,11 @@ bp::object executeCmd(bp::tuple args, bp::dict) {
     throw std::out_of_range("Wrong number of arguments");
   std::vector<Value> values;
   values.reserve(command.valueTypes().size());
-  for (int i = 1; i < bp::len(args); ++i)
-    values.push_back(convert::toValue(args[i], command.valueTypes()[i - 1]));
+  for (bp::ssize_t i = 1; i < bp::len(args); ++i)
+    values.push_back(convert::toValue
+                     (args[i],
+                      command.valueTypes()
+                      [static_cast<std::vector<Value>::size_type>(i - 1)]));
   command.setParameterValues(values);
   return convert::fromValue(command.execute());
 }

--- a/src/dynamic_graph/entity-py.cc
+++ b/src/dynamic_graph/entity-py.cc
@@ -84,10 +84,10 @@ bp::object executeCmd(bp::tuple args, bp::dict) {
   std::vector<Value> values;
   values.reserve(command.valueTypes().size());
   for (bp::ssize_t i = 1; i < bp::len(args); ++i)
-    values.push_back(convert::toValue
-                     (args[i],
-                      command.valueTypes()
-                      [static_cast<std::vector<Value>::size_type>(i - 1)]));
+    values.push_back(convert::toValue(
+        args[i],
+        command
+            .valueTypes()[static_cast<std::vector<Value>::size_type>(i - 1)]));
   command.setParameterValues(values);
   return convert::fromValue(command.execute());
 }

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -247,9 +247,9 @@ void Interpreter::runMain(void) {
 
 std::string Interpreter::processStream(std::istream& stream, std::ostream& os) {
   char line[10000];
-  sprintf(line, "%s", "\n");
-  std::string command;
   std::streamsize maxSize = 10000;
+  snprintf(line, static_cast<size_t>(maxSize), "%s", "\n");
+  std::string command;
 #if 0
   while (line != std::string("")) {
     stream.getline(line, maxSize, '\n');


### PR DESCRIPTION
This PR fixes a certain number of fixes:
 - Missing ```include(cmake/python.cmake)``` 
 - ```sprintf``` in ```interpreter.cpp``` which is deprecated.
 - Ambiguous ```long int``` and ```unsigned long int``` in convert-dg-to-py
 - Removed unused member ```locals_``` in ```Interpreter``` class.
 - Fix a cast (warning)